### PR TITLE
hotfix: date changes

### DIFF
--- a/R/nixtla_client_cross_validation.R
+++ b/R/nixtla_client_cross_validation.R
@@ -239,7 +239,6 @@ nixtla_client_cross_validation <- function(df, h=8, freq=NULL, id_col="unique_id
   idxs <- unlist(resp$idxs)+1 # R indices start at 0
 
   dates <- df$ds[idxs]
-  dates <- as.POSIXct(dates)
 
   yvals <- df$y[idxs]
 
@@ -247,7 +246,19 @@ nixtla_client_cross_validation <- function(df, h=8, freq=NULL, id_col="unique_id
   cutoff_idxs <- rep(idxs[window_starts + 1] - 1, each = h)
   cutoff_dates <- df$ds[unique(cutoff_idxs)]
   cutoff <- do.call(c, sapply(cutoff_dates, function(i) rep(i, times = h), simplify = FALSE))
-  cutoff <- as.POSIXct(cutoff)
+
+  if(inherits(df$ds, "character")){
+    if(max(nchar(df$ds)) <= 10){
+      dates <- lubridate::ymd(dates)
+      cutoff <- lubridate::ymd(cutoff)
+    }else{
+      dates <- lubridate::ymd_hms(dates, truncated = 3)
+      cutoff <- lubridate::ymd_hms(cutoff, truncated = 3)
+    }
+  }else{
+    dates <- as.POSIXct(dates)
+    cutoff <- as.POSIXct(cutoff)
+  }
 
   dt <- data.frame(
     unique_id = ids,

--- a/R/nixtla_client_detect_anomalies.R
+++ b/R/nixtla_client_detect_anomalies.R
@@ -135,11 +135,11 @@ nixtla_client_detect_anomalies <- function(df, freq=NULL, id_col="unique_id", ti
 
   df_tail <- purrr::map2_dfr(grouped_df_list, df_info$fitted_sizes, ~slice_tail(.x, n = .y))
 
-  nch <- nchar(df_tail$ds[1])
+  nch <- max(nchar(df_tail$ds))
   if(nch <= 10){
     df_tail$ds <- lubridate::ymd(df_tail$ds)
   }else{
-    df_tail$ds <- lubridate::ymd_hms(df_tail$ds)
+    df_tail$ds <- lubridate::ymd_hms(df_tail$ds, truncated = 3)
   }
 
   forecast <- cbind(df_tail, fc)

--- a/R/nixtla_client_forecast.R
+++ b/R/nixtla_client_forecast.R
@@ -171,7 +171,7 @@ nixtla_client_forecast <- function(df, h=8, freq=NULL, id_col="unique_id", time_
 
         message(paste0("Using future exogenous features: [", paste(names(future_exogenous), collapse=", "), "]"))
         names(future_exogenous) <- NULL
-        payload$series$X_future <- future_exogenous
+        payload$series$X_future <- lapply(future_exogenous, as.list) 
       }else{
         # hist_exog_list is non-empty
         not_hist_exog_list <- setdiff(names(df), c("unique_id", "ds", "y", hist_exog_list))
@@ -192,7 +192,7 @@ nixtla_client_forecast <- function(df, h=8, freq=NULL, id_col="unique_id", time_
 
         message(paste0("Using future exogenous features: [", paste(names(future_exogenous), collapse=", "), "]"))
         names(future_exogenous) <- NULL
-        payload$series$X_future <- future_exogenous
+        payload$series$X_future <- lapply(future_exogenous, as.list)
 
         message(paste0("Using historical exogenous features: [", paste(hist_exog_list, collapse=", "), "]"))
       }
@@ -268,16 +268,11 @@ nixtla_client_forecast <- function(df, h=8, freq=NULL, id_col="unique_id", time_
 
   # Add unique ids and dates to forecast ----
   if(inherits(df_info$last_ds, "character")){
-    if(length(df_info$last_ds) > 1){
-      dt <- sample(df_info$last_ds, 2)
-    }else{
-      dt <- df_info$last_ds[1]
-    }
-    nch <- max(nchar(as.character(dt)))
+    nch <- max(nchar(df_info$last_ds))
     if(nch <= 10){
       df_info$dates <- lubridate::ymd(df_info$last_ds)
     }else{
-      df_info$dates <- lubridate::ymd_hms(df_info$last_ds)
+      df_info$dates <- lubridate::ymd_hms(df_info$last_ds, truncated = 3)
     }
   }else{
     # assumes df_info$last_ds is already a date-object

--- a/R/nixtla_client_forecast.R
+++ b/R/nixtla_client_forecast.R
@@ -318,7 +318,8 @@ nixtla_client_forecast <- function(df, h=8, freq=NULL, id_col="unique_id", time_
       finetune_steps=finetune_steps,
       finetune_depth=finetune_depth,
       finetune_loss=finetune_loss,
-      clean_ex_first=clean_ex_first
+      clean_ex_first=clean_ex_first,
+      model=model
     )
 
     forecast <- dplyr::bind_rows(fitted, forecast)

--- a/R/nixtla_client_forecast.R
+++ b/R/nixtla_client_forecast.R
@@ -318,8 +318,7 @@ nixtla_client_forecast <- function(df, h=8, freq=NULL, id_col="unique_id", time_
       finetune_steps=finetune_steps,
       finetune_depth=finetune_depth,
       finetune_loss=finetune_loss,
-      clean_ex_first=clean_ex_first,
-      model=model
+      clean_ex_first=clean_ex_first
     )
 
     forecast <- dplyr::bind_rows(fitted, forecast)

--- a/R/nixtla_client_historic.R
+++ b/R/nixtla_client_historic.R
@@ -179,12 +179,10 @@ nixtla_client_historic <- function(df, freq=NULL, id_col="unique_id", time_col="
   dates <- dates |>
     dplyr::select(dplyr::all_of(c("unique_id", "ds")))
 
-  nch <- nchar(dates$ds[1])
+  nch <- max(nchar(dates$ds))
   if(nch <= 10){
     dates$ds <- lubridate::ymd(dates$ds)
   }else{
-    # truncated = 3 lets midnight timestamps that render as date-only
-    # ("YYYY-MM-DD") still parse, avoiding NA timestamps in the output.
     dates$ds <- lubridate::ymd_hms(dates$ds, truncated = 3)
   }
 

--- a/R/nixtla_client_plot.R
+++ b/R/nixtla_client_plot.R
@@ -77,7 +77,9 @@ nixtla_client_plot <- function(df, fcst=NULL, h=NULL, id_col="unique_id", time_c
     if(nch <= 10){
       df$ds <- lubridate::ymd(df$ds)
     }else{
-      df$ds <- lubridate::ymd_hms(df$ds)
+      # truncated = 3 lets midnight timestamps that render as date-only
+      # ("YYYY-MM-DD") still parse, avoiding NA timestamps in the output.
+      df$ds <- lubridate::ymd_hms(df$ds, truncated = 3)
     }
   }
 


### PR DESCRIPTION
## Description

Adds date-handling changes that were uncommitted on #62 and missed when #62 merged. These updates make parsing more robust and align the other client functions with the approach already used in `infer_frequency` and `nixtla_client_historic`.